### PR TITLE
fix: dotenv is a devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@airstack/frames",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@airstack/frames",
-      "version": "1.1.11",
+      "version": "1.1.12",
       "license": "MIT",
       "dependencies": {
         "@airstack/node": "^0.0.6",

--- a/src/middlewares/framesjs/onchainData.ts
+++ b/src/middlewares/framesjs/onchainData.ts
@@ -19,12 +19,9 @@ import {
   OnchainDataInput,
   OnchainDataOutput,
 } from "../../types";
-import { config } from "dotenv";
 import { decodeFrameActionPayloadFromRequest } from "../../utils/decodeFrameActionPayloadFromRequest";
 import { FrameActionMessage, Message } from "@farcaster/core";
 import { config as configEnv } from "../../config";
-
-config();
 
 /**
  *


### PR DESCRIPTION
 - not always installed
 - is a user concern
 - process.env not read in this file
apparently a lockfile updated to the latest version of airstack/frames in the process of `npm i`? eh? recursive lock?